### PR TITLE
Adding sentence link for files without AV

### DIFF
--- a/jsx/App/Stories/Story/Display/Untimed.jsx
+++ b/jsx/App/Stories/Story/Display/Untimed.jsx
@@ -1,17 +1,37 @@
 import id from 'shortid';
 import { Sentence } from "./Sentence.jsx";
 
+function UntimedBlock({ sentence, sentenceId }) {
+	return (
+		<div className="untimedBlock">
+			<span className="timeStampContainer timeStamp" data-sentence_id={sentenceId}>
+				{sentenceId}
+			</span>
+			<Sentence sentence={sentence} />
+		</div>
+	);
+}
+
 export function UntimedTextDisplay({ sentences }) {
 	// I/P: sentences, a list of sentences
 	// O/P: the main gloss view, with several Sentences arranged vertically, each wrapped in an UntimedBlock
 	// Status: tested, working
 	let output = [];
+	let sentenceCount = 1; 
 	for (const sentence of sentences) {
 		output.push(
-			<div key={id.generate()} className="untimedBlock">
-				<Sentence key={id.generate()} sentence={sentence} />
-			</div>
+			<UntimedBlock 
+				key={id.generate()} 
+				sentence={sentence} 
+				sentenceId={sentenceCount} 
+			/>
+			
+			// ----- Original code -----
+			// <div key={id.generate()} className="untimedBlock">
+			// 	<Sentence key={id.generate()} sentence={sentence} />
+			// </div>
 		);
+		sentenceCount += 1; 
 	}
 	return <div id="untimedTextDisplay">{output}</div>;
 }

--- a/jsx/App/Stories/Story/Display/Untimed.jsx
+++ b/jsx/App/Stories/Story/Display/Untimed.jsx
@@ -25,11 +25,6 @@ export function UntimedTextDisplay({ sentences }) {
 				sentence={sentence} 
 				sentenceId={sentenceCount} 
 			/>
-			
-			// ----- Original code -----
-			// <div key={id.generate()} className="untimedBlock">
-			// 	<Sentence key={id.generate()} sentence={sentence} />
-			// </div>
 		);
 		sentenceCount += 1; 
 	}

--- a/jsx/App/Stories/Story/Story.jsx
+++ b/jsx/App/Stories/Story/Story.jsx
@@ -17,7 +17,6 @@ export class Story extends React.Component {
 
         // If there is a footer, i.e., if audio exists:
         if ($('#footer').length !== 0) {
-            //setupTextSync();
             // If video exists:
             if ($('#video').length !== 0) {
                 Video.show();
@@ -46,7 +45,7 @@ export class Story extends React.Component {
             }
             const audioFilePath = getMediaFilePath(audioFile);
             footer = <div id="footer"><audio data-live="true" controls controlsList="nodownload" id="audio" src={audioFilePath}/></div>;
-        } 
+        }
         return (
             <div>
                 <div id="middle">

--- a/jsx/App/Stories/Story/Story.jsx
+++ b/jsx/App/Stories/Story/Story.jsx
@@ -13,9 +13,11 @@ export class Story extends React.Component {
         const storyJSON = await import(`~./data/json_files/${this.props.storyID}.json`);
         this.setState({ story: storyJSON.default });
 
+        setupTextSync();
+
         // If there is a footer, i.e., if audio exists:
         if ($('#footer').length !== 0) {
-            setupTextSync();
+            //setupTextSync();
             // If video exists:
             if ($('#video').length !== 0) {
                 Video.show();
@@ -31,7 +33,6 @@ export class Story extends React.Component {
         }
 
         const story = this.state.story;
-        console.log(story);
         const sentences = story['sentences'];
         const timed = (story['metadata']['timed']);
         let footer = null;
@@ -45,7 +46,7 @@ export class Story extends React.Component {
             }
             const audioFilePath = getMediaFilePath(audioFile);
             footer = <div id="footer"><audio data-live="true" controls controlsList="nodownload" id="audio" src={audioFilePath}/></div>;
-        }
+        } 
         return (
             <div>
                 <div id="middle">

--- a/jsx/App/Stories/Story/lib/txt_sync.js
+++ b/jsx/App/Stories/Story/lib/txt_sync.js
@@ -1,6 +1,37 @@
 // Based on http://community.village.virginia.edu/etst/
 
 export function setupTextSync() {
+
+    // "media" is undefined if there are no AV files associated with the current text. 
+    // Holly's change on Oct 5, 2020: 
+    // This block used to be a try-catch block, I changed it so that when there are no AV files
+    // this block doesn't throw any error to the console. 
+    const media = document.querySelectorAll("[data-live='true']")[0];
+    let ts_tag_array = []; // Array that stores all timestamps/sentence id
+    let ts_start_time_array = [];
+    let ts_stop_time_array = [];
+
+    if (media) {
+        media.setAttribute("ontimeupdate", "sync(this.currentTime)");
+        media.setAttribute("onclick", "sync(this.currentTime)");
+
+        ts_tag_array = document.getElementsByClassName("labeledTimeBlock");
+        for (var i = 0; i < ts_tag_array.length; i++) {
+            ts_start_time_array[i] = ts_tag_array[i].getAttribute("data-start_time");
+            ts_stop_time_array[i] = ts_tag_array[i].getAttribute("data-end_time");
+        }
+    } else {
+        ts_tag_array = document.getElementsByClassName("untimedBlock");
+    }
+
+    // try {
+    //     const media = document.querySelectorAll("[data-live='true']")[0];
+    //     media.setAttribute("ontimeupdate", "sync(this.currentTime)");
+    //     media.setAttribute("onclick", "sync(this.currentTime)");
+    // } catch (err) {
+    //     console.log(err);
+    // }
+
     function scrollIntoViewIfNeeded(target) {
         var rect = target.getBoundingClientRect();
         if (rect.bottom > window.innerHeight) {
@@ -16,62 +47,88 @@ export function setupTextSync() {
             // Somewhat hacky solution: decrease current_time by 0.001 to avoid highlighting before player starts
             if ((current_time-0.001 >= parseFloat(ts_start_time_array[i])/1000.0) && (current_time <= parseFloat(ts_stop_time_array[i])/1000.0)) {
                 ts_tag_array[i].setAttribute("id", "current");
-                // $('#example, #td').animate({scrollTop:$("#current").offset().top}, 500);
                 scrollIntoViewIfNeeded($("#current")[0]);
-                ts_tag_array[i].style.backgroundColor = "rgb(209, 200, 225)";
+                changeSentenceColorToHighlight(i); 
             }
             else {
-                ts_tag_array[i].style.backgroundColor = "transparent";
+                changeSentenceColorToNormal(i);
                 try { ts_tag_array[i].removeAttribute("id"); }
                 catch (err) { }
             }
         }
     }
 
-    try {
-        const media = document.querySelectorAll("[data-live='true']")[0];
-        media.setAttribute("ontimeupdate", "sync(this.currentTime)");
-        media.setAttribute("onclick", "sync(this.currentTime)");
-    } catch (err) {
-        console.log(err);
+    // Two functions that change the color of a sentence to either highlight or normal.
+    function changeSentenceColorToHighlight(timestampIndex) {
+        ts_tag_array[timestampIndex].style.backgroundColor = "rgb(209, 200, 225)";
+    }
+    function changeSentenceColorToNormal(timestampIndex) {
+        ts_tag_array[timestampIndex].style.backgroundColor = "transparent";
     }
 
-    const ts_tag_array = document.getElementsByClassName("labeledTimeBlock");
-    const ts_start_time_array = [];
-    const ts_stop_time_array = [];
-
-    for (var i = 0; i < ts_tag_array.length; i++) {
-        ts_start_time_array[i] = ts_tag_array[i].getAttribute("data-start_time");
-        ts_stop_time_array[i] = ts_tag_array[i].getAttribute("data-end_time");
-    }
-    // }
+    // OnClick function for each timestamp
+    $(".timeStamp").click(function() {
+        const newTime = $(this).data('start_time');
+        if (newTime) {
+            updateTimestampQuery(newTime);
+            setMediaCurrentTime(newTime);
+        } else {
+            // A file without AV files will not have newTime associated with each sentence.
+            // In this case, use the sentence id as part of the new URL after selecting a sentence. 
+            const sentId = $(this).data('sentence_id');
+            updateTimestampQuery(sentId);
+            for (var i = 0; i < ts_tag_array.length; i++) {
+                // sentence id starts with 1
+                if (i+1 == sentId) {
+                    changeSentenceColorToHighlight(i);
+                } else {
+                    changeSentenceColorToNormal(i);
+                }
+            }
+        }
+        // document.location.search = $(this).data('start_time');
+    });
 
     // I/P: t, an integer number of milliseconds
     // O/P: the player updates to the given time
     // Status: untested
-    function jumpToTime(t) {
-        updateTimestampQuery(t);
-        try {
-            const media = $("[data-live='true']").get(0);
+    // This function adjusts the AV file(s)' timestamp according to the 
+    // selected sentence's URL
+    function setMediaCurrentTime(t) {
+        // change by Holly, October 3, 2020: I moved the updateTimestampQuery call to 
+        // be part of the onclick of .timeStamp
+        const media = $("[data-live='true']").get(0);
+        if (media) {
             media.currentTime = (t + 2) / 1000;
         }
-        catch(err) {
-            console.log(err);
-            console.log("We think you tried to jump to time before the MEDIA element was created.")
+        // try {
+        //     const media = $("[data-live='true']").get(0);
+        //     media.currentTime = (t + 2) / 1000;
+        // }
+        // catch(err) {
+        //     console.log(err);
+        //     console.log("We think you tried to jump to time before the MEDIA element was created.")
+        // }
+    }
+
+    function updateTimestampQuery(newSentenceIndex) {
+        if (window.history.replaceState) {
+            // const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.hash.replace(/\?.*$/, ''); // hacky...
+            // TODO: need to deal with this -1 somehow...
+            const newurl = window.location.href.replace(/\?.*$/,'') + `?${newSentenceIndex-1}`; // hacky...
+            window.history.replaceState({ path: newurl }, '', newurl);
         }
     }
 
-    $(".timeStamp").click(function() {
-        jumpToTime($(this).data('start_time'));
-        // document.location.search = $(this).data('start_time');
-    });
 
     // Jump to timestamp:
     // Source: http://snydersoft.com/blog/2009/11/14/get-parameters-to-html-page-with-javascript/
     $( document ).ready(function() {
+        // This sentenceTimestampId is the timestamp for a file with AV, 
+        // and a sentence id for a file without AV. 
         let query_index = document.URL.indexOf("?");
-        let startTime = Number(document.URL.substr(query_index+1));
-        if (isFinite(startTime)) {
+        let sentenceTimestampId = Number(document.URL.substr(query_index+1));
+        if (isFinite(sentenceTimestampId)) {
             // startTime = startTime + 3 // do not remove (result of hacky solution further up in this file)
             // const media = $("[data-live='true']").get(0);
             
@@ -84,15 +141,11 @@ export function setupTextSync() {
             //console.log(startTime);
             //jumpToTime(startTime);
             //console.log(document.getElementById(startTime));
-            jumpToTime(startTime + 1);
+
+            // TODO: will this work with non-AV files?
+            setMediaCurrentTime(sentenceTimestampId + 1);
         }
     });
 
-    function updateTimestampQuery(newTimestamp) {
-        if (window.history.replaceState) {
-            // const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.hash.replace(/\?.*$/, ''); // hacky...
-            const newurl = window.location.href.replace(/\?.*$/,'') + `?${newTimestamp-1}`; // hacky...
-            window.history.replaceState({ path: newurl }, '', newurl);
-        }
-    }
+    
 }

--- a/preprocessing/preprocess_flex.js
+++ b/preprocessing/preprocess_flex.js
@@ -112,8 +112,6 @@ function getSentenceToken(word) {
 //   one word within the sentence text
 // returns the sentence as a string with correct punctuation and spacing
 function concatWords(sentenceTokens) {
-  //console.log("===CONCAT WORDS====="); 
-  //console.log(sentenceTokens); 
   let sentenceText = "";
   let maybeAddSpace = false; // no space before first word
   for (const typedToken of sentenceTokens) {
@@ -124,8 +122,6 @@ function concatWords(sentenceTokens) {
     // If the word token's value is undefined, skip this word.
     sentenceText += typedToken["value"] || "";
   }
-  //console.log(sentenceText);
-  //console.log("===========");
   return sentenceText;
 }
 


### PR DESCRIPTION
I mostly changed the txt_sync.jsx so that, in files without AV, each sentence receives an id that represents a counter beginning at 1 and is assigned to each sentence. This sentence id is also the corresponding query index in the sentence's URL at the position after ? , and inputing a specific sentence's URL should trigger the page to scroll to the requested sentence and highlight it in the purple color. 

[Note: the changes in preprocess_flex.js seems to be changes I already committed to the master branch but haven't merged yet.. Trying to merge in the master branch locally right now creates a few conflicts for me, so I think I will leave the preprocess_flex changes in this PR for right now. Eventually, when I merge this PR, the changes in preprocess_flex should be the same as what the master branch already has. 